### PR TITLE
FIX for IndexError: list index out of range

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -530,7 +530,7 @@ class PyreResponse:
        return self.pyres[index]
 
     def val(self):
-        if isinstance(self.pyres, list):
+        if isinstance(self.pyres, list) and self.pyres:
             # unpack pyres into OrderedDict
             pyre_list = []
             # if firebase response was a list


### PR DESCRIPTION
Added validation.

No validation that self.pyres object isn't null only if it's a list.
If the list is empty, pyrebase crashes due to pyres[0] cant be found since there is no index of 0 to be found.