### PR TITLE
Fixed a KeyError raised when the sort key is missing

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -299,7 +299,7 @@ class Database:
             elif build_query["orderBy"] == "$value":
                 sorted_response = sorted(request_dict.items(), key=lambda item: item[1])
             else:
-                sorted_response = sorted(request_dict.items(), key=lambda item: item[1][build_query["orderBy"]])
+                sorted_response = sorted(request_dict.items(), key=lambda item: (build_query["orderBy"] in item[1], item[1].get(build_query["orderBy"], ""))
         return PyreResponse(convert_to_pyre(sorted_response), query_key)
 
     def push(self, data, token=None, json_kwargs={}):


### PR DESCRIPTION
**Existing Behavior:**
When fetching data and using a sort key that only exists on some items fetched, a `KeyError` will be raised.

**New Behavior:**
Missing keys are sorted first to maintain consistency with the official firebase libraries.

A tuple is returned to the sorted function. The first key will be a boolean and the second key will be the value of the sort key or an empty string.

If the sort key is missing, the first key in the tuple will be `False` and ordered first which is the behavior documented in the official firebase documentation. The second key in the tuple will be an empty string giving all items without a sort key equal weighting.

If the sort key is available, the first key in the tuple will be true and the second value will be the value of the sort key to sort on.