### PR TITLE
Fix syntax error by adding missing closing parenthesis

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -299,7 +299,7 @@ class Database:
             elif build_query["orderBy"] == "$value":
                 sorted_response = sorted(request_dict.items(), key=lambda item: item[1])
             else:
-                sorted_response = sorted(request_dict.items(), key=lambda item: (build_query["orderBy"] in item[1], item[1].get(build_query["orderBy"], ""))
+                sorted_response = sorted(request_dict.items(), key=lambda item: (build_query["orderBy"] in item[1], item[1].get(build_query["orderBy"], "")))
         return PyreResponse(convert_to_pyre(sorted_response), query_key)
 
     def push(self, data, token=None, json_kwargs={}):


### PR DESCRIPTION
It seems in the most recent version of Pyrebase a syntax error was introduced into the code, caused by a missing closing parenthesis.  This was pointed out in a <a href="https://stackoverflow.com/questions/65373887/why-do-i-get-an-error-from-pyrebase4-after-updating-it">Stack Overflow question</a>.  This PR fixes it.