### PR TITLE
fixed None path breaking in get_url()

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -503,7 +503,7 @@ class Storage:
         # remove leading backlash
         url = self.get_url(token)
         if path.startswith('/'):
-            path = path[1:]
+            path = path.lstrip('/')
         if self.credentials:
             blob = self.bucket.get_blob(path)
             if not blob is None:
@@ -523,10 +523,10 @@ class Storage:
                         f.write(chunk)
 
     def get_url(self, token):
-        path = self.path
+        path = self.path if self.path else ''
         self.path = None
         if path.startswith('/'):
-            path = path[1:]
+            path = path.lstrip('/')
         if token:
             return "{0}/o/{1}?alt=media&token={2}".format(self.storage_bucket, quote(path, safe=''), token)
         return "{0}/o/{1}?alt=media".format(self.storage_bucket, quote(path, safe=''))


### PR DESCRIPTION
### Fixed None Path breaking the code in get_url() function. 
---

**Title**: Improved download and get_url methods in Storage class

---

### Description:

This PR addresses issues with the `download` and `get_url` methods in the `Storage` class. The changes ensure more consistent behavior and cleaner code.

### Changes:

1. **Download Method**:
   - Simplified the path stripping logic.
   - Used `lstrip` for cleaner removal of leading slashes.

2. **Get URL Method**:
   - Used ternary condition to simplify the logic.
   - Used `lstrip` to ensure consistent behavior.

### Code Changes:

**Before**:
```python
def download(self, path, filename, token=None):
    ...
    if path.startswith('/'):
        path = path[1:]
    ...
def get_url(self, token):
    ...
    if path.startswith('/'):
        path = path[1:]
    ...
```

**After**:
```python
def download(self, path, filename, token=None):
    ...
    path = path.lstrip('/')
    ...
def get_url(self, token):
    ...
    path = self.path if self.path else ''
    path = path.lstrip('/')
    ...
```

### Impact:
These changes result in a cleaner and more maintainable codebase. They also ensure consistent behavior when manipulating paths in the `Storage` class.

---


**Credits: @ndesamuelmbah**