### PR TITLE
Updated to use PyJwt as Python_jwt is deprecated

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -19,7 +19,7 @@ from requests_toolbelt.adapters import appengine
 from uuid import uuid4
 
 import python_jwt as jwt
-from Crypto.PublicKey import RSA
+import jwt as jwt
 import datetime
 
 
@@ -94,19 +94,22 @@ class Auth:
         self.current_user = request_object.json()
         return request_object.json()
 
+    # Updated to use PyJwt as Python_jwt is deprecated
     def create_custom_token(self, uid, additional_claims=None, expiry_minutes=60):
         service_account_email = self.credentials.service_account_email
-        private_key = RSA.importKey(self.credentials._private_key_pkcs8_pem)
+        private_key = self.credentials._private_key_pkcs8_pem 
         payload = {
             "iss": service_account_email,
             "sub": service_account_email,
             "aud": "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit",
-            "uid": uid
+            "uid": uid,
+            "iat": datetime.datetime.now(datetime.timezone.utc),  # issued at time
+            "exp": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=expiry_minutes)  # expiration time
         }
         if additional_claims:
-            payload["claims"] = additional_claims
-        exp = datetime.timedelta(minutes=expiry_minutes)
-        return jwt.generate_jwt(payload, private_key, "RS256", exp)
+            payload.update(additional_claims)
+        token = jwt.encode(payload, private_key, algorithm="RS256") #create token
+        return token
 
     def sign_in_with_custom_token(self, token):
         request_ref = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyCustomToken?key={0}".format(self.api_key)


### PR DESCRIPTION
Slightly modified create_custom_token to use PyJwt as Python_jwt is deprecated