### PR TITLE
drop support for appengine

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -15,7 +15,6 @@ import threading
 import socket
 from oauth2client.service_account import ServiceAccountCredentials
 from gcloud import storage
-from requests_toolbelt.adapters import appengine
 from uuid import uuid4
 
 import python_jwt as jwt
@@ -47,13 +46,8 @@ class Firebase:
                 self.credentials = ServiceAccountCredentials.from_json_keyfile_name(config["serviceAccount"], scopes)
             if service_account_type is dict:
                 self.credentials = ServiceAccountCredentials.from_json_keyfile_dict(config["serviceAccount"], scopes)
-        if is_appengine_sandbox():
-            # Fix error in standard GAE environment
-            # is releated to https://github.com/kennethreitz/requests/issues/3187
-            # ProtocolError('Connection aborted.', error(13, 'Permission denied'))
-            adapter = appengine.AppEngineAdapter(max_retries=3)
-        else:
-            adapter = HTTPAdapter()
+        
+        adapter = HTTPAdapter()
 
         for scheme in ('http://', 'https://'):
             self.requests.mount(scheme, adapter)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests-toolbelt>=0.7.1,<1.0
+requests-toolbelt>=1.0.0
 requests>=2.31
 urllib3>=1.21.1,<2
 gcloud>=0.18.3


### PR DESCRIPTION
this feature is not used broadly and is blocking supporting newer versions of requests-toolbelt, making this project incompatible with other software